### PR TITLE
Fix `write_documents` return value

### DIFF
--- a/src/milvus_haystack/document_store.py
+++ b/src/milvus_haystack/document_store.py
@@ -76,6 +76,9 @@ class MilvusDocumentStore:
 
         # Default search params when one is not provided.
         self.default_search_params = {
+            "GPU_IVF_FLAT": {"metric_type": "L2", "params": {"nprobe": 10}},
+            "GPU_IVF_PQ": {"metric_type": "L2", "params": {"nprobe": 10}},
+            "GPU_CAGRA": {"metric_type": "L2", "params": {"itopk_size": 128}},
             "IVF_FLAT": {"metric_type": "L2", "params": {"nprobe": 10}},
             "IVF_SQ8": {"metric_type": "L2", "params": {"nprobe": 10}},
             "IVF_PQ": {"metric_type": "L2", "params": {"nprobe": 10}},
@@ -323,6 +326,7 @@ class MilvusDocumentStore:
         total_count = len(vectors)
 
         batch_size = 1000
+        wrote_ids = []
         if not isinstance(self.col, Collection):
             raise MilvusException(message="Collection is not initialized")
         for i in range(0, total_count, batch_size):
@@ -334,12 +338,12 @@ class MilvusDocumentStore:
             try:
                 # res: Collection
                 res = self.col.insert(insert_list, timeout=None, **kwargs)
-                ids.extend(res.primary_keys)
+                wrote_ids.extend(res.primary_keys)
             except MilvusException as err:
                 logger.error("Failed to insert batch starting at entity: %s/%s", i, total_count)
                 raise err
         self.col.flush()
-        return len(ids)
+        return len(wrote_ids)
 
     def delete_documents(self, document_ids: List[str]) -> None:
         """

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -26,10 +26,11 @@ class TestDocumentStore(CountDocumentsTest, WriteDocumentsTest, DeleteDocumentsT
         )
 
     def test_write_documents(self, document_store: DocumentStore):
-        document_store.write_documents(
+        return_value = document_store.write_documents(
             [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
         )
         assert document_store.count_documents() == 3
+        assert return_value == 3
 
     def test_delete_documents(self, document_store: DocumentStore):
         """


### PR DESCRIPTION
- Add default search params for GPU indexes to avoid exceptions
- Fix `write_documents` return value
- Test `write_documents` return value