### PR TITLE
[Feature Request] Add runtime filter support to MilvusEmbeddingRetriever

### DIFF
--- a/src/milvus_haystack/milvus_embedding_retriever.py
+++ b/src/milvus_haystack/milvus_embedding_retriever.py
@@ -57,7 +57,8 @@ class MilvusEmbeddingRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, query_embedding: List[float], top_k: Optional[int] = None) -> Dict[str, List[Document]]:
+    def run(self, query_embedding: List[float], top_k: Optional[int] = None, filters: Optional[Dict[str, Any]] = None
+) -> Dict[str, List[Document]]:
         """
         Retrieve documents from the `MilvusDocumentStore`, based on their dense embeddings.
 
@@ -66,8 +67,8 @@ class MilvusEmbeddingRetriever:
         """
         docs = self.document_store._embedding_retrieval(
             query_embedding=query_embedding,
-            filters=self.filters,
             top_k=top_k or self.top_k,
+            filters=filters or self.filters,
         )
         return {"documents": docs}
 
@@ -125,6 +126,7 @@ class MilvusSparseEmbeddingRetriever:
         query_sparse_embedding: Optional[SparseEmbedding] = None,
         query_text: Optional[str] = None,
         top_k: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None
     ) -> Dict[str, List[Document]]:
         """
         Retrieve documents from the `MilvusDocumentStore`, based on their sparse embeddings.
@@ -134,8 +136,8 @@ class MilvusSparseEmbeddingRetriever:
         """
         docs = self.document_store._sparse_embedding_retrieval(
             query_sparse_embedding=query_sparse_embedding,
-            filters=self.filters,
             top_k=top_k or self.top_k,
+            filters=filters or self.filters,
             query_text=query_text,
         )
         return {"documents": docs}
@@ -221,6 +223,7 @@ class MilvusHybridRetriever:
         query_sparse_embedding: Optional[SparseEmbedding] = None,
         query_text: Optional[str] = None,
         top_k: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None
     ):
         """
         Retrieve documents from the `MilvusDocumentStore`, based on their dense and sparse embeddings.
@@ -232,7 +235,7 @@ class MilvusHybridRetriever:
         docs = self.document_store._hybrid_retrieval(
             query_embedding=query_embedding,
             query_sparse_embedding=query_sparse_embedding,
-            filters=self.filters,
+            filters= filters or self.filters,
             top_k=top_k or self.top_k,
             reranker=self.reranker,
             query_text=query_text,

--- a/tests/test_embedding_retriever.py
+++ b/tests/test_embedding_retriever.py
@@ -77,6 +77,42 @@ class TestMilvusEmbeddingTests:
         assert len(res["documents"]) == 10
         assert_docs_equal_except_score(res["documents"][0], documents[5])
 
+    def test_run_using_filters(self, document_store: MilvusDocumentStore):
+        """Test that filters are properly applied at runtime"""
+        documents = []
+        for i in range(10):
+            doc = Document(
+                content=f"Document {i}",
+                meta={
+                    "name": f"name_{i}",
+                    "page": str(100 + i),
+                    "chapter": "intro" if i < 5 else "outro",
+                    "number": i,
+                    "date": "1969-07-21T20:17:40",
+                },
+                embedding=l2_normalization([0.5] * 63 + [0.1 * i]),
+            )
+            documents.append(doc)
+        document_store.write_documents(documents)
+
+        # Test with runtime filters
+        retriever = MilvusEmbeddingRetriever(document_store)
+        query_embedding = l2_normalization([0.5] * 64)
+
+        # Filter: chapter == "intro" (should return 5 documents)
+        filters = {"field": "chapter", "operator": "==", "value": "intro"}
+        res = retriever.run(query_embedding, filters=filters)
+        assert len(res["documents"]) == 5
+        for doc in res["documents"]:
+            assert doc.meta["chapter"] == "intro"
+
+        # Filter: number >= 5 (should return 5 documents)
+        filters = {"field": "number", "operator": ">=", "value": 5}
+        res = retriever.run(query_embedding, filters=filters)
+        assert len(res["documents"]) == 5
+        for doc in res["documents"]:
+            assert doc.meta["number"] >= 5
+
     def test_to_dict(self, document_store: MilvusDocumentStore):
         expected_dict = {
             "type": "src.milvus_haystack.document_store.MilvusDocumentStore",
@@ -209,6 +245,43 @@ class TestMilvusSparseEmbeddingTests:
         res = retriever.run(sparse_query_embedding)
         assert len(res["documents"]) == 10
         assert_docs_equal_except_score(res["documents"][0], documents[5])
+
+    def test_run_using_filters(self, document_store: MilvusDocumentStore):
+        """Test that filters are properly applied at runtime for sparse retrieval"""
+        documents = []
+        for i in range(10):
+            doc = Document(
+                content=f"Document {i}",
+                meta={
+                    "name": f"name_{i}",
+                    "page": str(100 + i),
+                    "chapter": "intro" if i < 5 else "outro",
+                    "number": i,
+                    "date": "1969-07-21T20:17:40",
+                },
+                embedding=l2_normalization([0.5] * 64),
+                sparse_embedding=SparseEmbedding(indices=[0, 1, 2 + i], values=[1.0, 2.0, 3.0]),
+            )
+            documents.append(doc)
+        document_store.write_documents(documents)
+
+        # Test with runtime filters
+        retriever = MilvusSparseEmbeddingRetriever(document_store)
+        sparse_query_embedding = SparseEmbedding(indices=[0, 1, 2 + 5], values=[1.0, 2.0, 3.0])
+
+        # Filter: chapter == "outro" (should return 5 documents)
+        filters = {"field": "chapter", "operator": "==", "value": "outro"}
+        res = retriever.run(sparse_query_embedding, filters=filters)
+        assert len(res["documents"]) == 5
+        for doc in res["documents"]:
+            assert doc.meta["chapter"] == "outro"
+
+        # Filter: number < 3 (should return 3 documents)
+        filters = {"field": "number", "operator": "<", "value": 3}
+        res = retriever.run(sparse_query_embedding, filters=filters)
+        assert len(res["documents"]) == 3
+        for doc in res["documents"]:
+            assert doc.meta["number"] < 3
 
     def test_fail_without_sparse_field(self, documents: List[Document]):
         document_store = MilvusDocumentStore(
@@ -365,6 +438,52 @@ class TestMilvusHybridTests:
         )
         assert len(res["documents"]) == 10
         assert_docs_equal_except_score(res["documents"][0], documents[5])
+
+    def test_run_using_filters(self, document_store: MilvusDocumentStore):
+        """Test that filters are properly applied at runtime for hybrid retrieval"""
+        documents = []
+        for i in range(10):
+            doc = Document(
+                content=f"Hybrid Document {i}",
+                meta={
+                    "name": f"name_{i}",
+                    "page": str(100 + i),
+                    "chapter": "intro" if i < 5 else "outro",
+                    "number": i,
+                    "date": "1969-07-21T20:17:40",
+                },
+                embedding=l2_normalization([0.5] * 63 + [0.45 + 0.01 * i]),
+                sparse_embedding=SparseEmbedding(indices=[0, 1, 2 + i], values=[1.0, 2.0, 3.0]),
+            )
+            documents.append(doc)
+        document_store.write_documents(documents)
+
+        # Test with runtime filters
+        retriever = MilvusHybridRetriever(document_store)
+        query_embedding = l2_normalization([0.5] * 64)
+        sparse_query_embedding = SparseEmbedding(indices=[0, 1, 2 + 5], values=[1.0, 2.0, 3.0])
+
+        # Filter: chapter == "intro" (should return 5 documents)
+        filters = {"field": "chapter", "operator": "==", "value": "intro"}
+        res = retriever.run(
+            query_embedding=query_embedding,
+            query_sparse_embedding=sparse_query_embedding,
+            filters=filters,
+        )
+        assert len(res["documents"]) == 5
+        for doc in res["documents"]:
+            assert doc.meta["chapter"] == "intro"
+
+        # Filter: number in [2, 4, 6, 8] (should return 4 documents)
+        filters = {"field": "number", "operator": "in", "value": [2, 4, 6, 8]}
+        res = retriever.run(
+            query_embedding=query_embedding,
+            query_sparse_embedding=sparse_query_embedding,
+            filters=filters,
+        )
+        assert len(res["documents"]) == 4
+        for doc in res["documents"]:
+            assert doc.meta["number"] in [2, 4, 6, 8]
 
     def test_fail_without_sparse_field(self, documents: List[Document]):
         document_store = MilvusDocumentStore(


### PR DESCRIPTION
## 📝 Description

This PR adds runtime filter parameter support to all retriever classes (`MilvusEmbeddingRetriever`, `MilvusSparseEmbeddingRetriever`, and `MilvusHybridRetriever`), enabling dynamic metadata filtering at query time.

## 🎯 Motivation

Previously, filters could only be set during retriever initialization. This limitation prevented users from dynamically changing filter conditions at runtime, which is a common use case in production environments where filter criteria may vary per query.

- issues: #67 
- reference pr: #45 


## 🔧 Changes

### Code Changes
- **`MilvusEmbeddingRetriever.run()`**: Added optional `filters` parameter
- **`MilvusSparseEmbeddingRetriever.run()`**: Added optional `filters` parameter  
- **`MilvusHybridRetriever.run()`**: Added optional `filters` parameter

All retrievers now support both:
1. **Static filters**: Set during initialization (existing behavior)
2. **Runtime filters**: Pass `filters` parameter to `run()` method (new feature)

Runtime filters take precedence over static filters when both are provided.

### Test Coverage
Added comprehensive test coverage with `test_run_using_filters()` for each retriever class:
- **`TestMilvusEmbeddingTests.test_run_using_filters()`**: Tests dense embedding retrieval with runtime filters
- **`TestMilvusSparseEmbeddingTests.test_run_using_filters()`**: Tests sparse embedding retrieval with runtime filters
- **`TestMilvusHybridTests.test_run_using_filters()`**: Tests hybrid retrieval with runtime filters


## 📊 Example Usage

```python
# Initialize retriever (with optional static filter)
retriever = MilvusEmbeddingRetriever(document_store)

# Apply runtime filter for specific query
filters = {"field": "category", "operator": "==", "value": "news"}
results = retriever.run(query_embedding, filters=filters)

# Different filter for next query
filters = {"field": "year", "operator": ">=", "value": 2023}
results = retriever.run(query_embedding, filters=filters)

