### PR TITLE
Replace ORM Collection/utility with MilvusClient API (pymilvus 2.5.x/2.6.x compatibility)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,11 @@ jobs:
     name: Run Lint and Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.9' ]
-    
+        pymilvus-version: [ '2.5.*', '2.6.*' ]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,6 +36,9 @@ jobs:
 
       - name: Lint
         run: hatch run lint:all
+
+      - name: Pin pymilvus ${{ matrix.pymilvus-version }}
+        run: hatch run pip install "pymilvus==${{ matrix.pymilvus-version }}"
 
       - name: Run Milvus
         run: |

--- a/src/milvus_haystack/document_store.py
+++ b/src/milvus_haystack/document_store.py
@@ -11,14 +11,12 @@ from haystack.errors import FilterError
 from haystack.utils import Secret, deserialize_secrets_inplace
 from pymilvus import (
     AnnSearchRequest,
-    Collection,
     CollectionSchema,
     DataType,
     FieldSchema,
     MilvusClient,
     MilvusException,
     RRFRanker,
-    utility,
 )
 from pymilvus.client.abstract import BaseRanker
 from pymilvus.client.types import LoadState
@@ -194,33 +192,23 @@ class MilvusDocumentStore:
         self._check_function()
 
         # Create the connection to the server
-        if connection_args is None:
-            self.connection_args = DEFAULT_MILVUS_CONNECTION
-        self._milvus_client = MilvusClient(
-            **self.connection_args,
-        )
-        self.alias = self.client._using
-        self.col: Optional[Collection] = None
+        resolved_args = connection_args if connection_args is not None else DEFAULT_MILVUS_CONNECTION
+        self.connection_args = resolved_args
+        self._milvus_client = MilvusClient(**resolved_args)
+        self.col: bool = False  # True when the collection is ready to use
 
         # Grab the existing collection if it exists
-        if utility.has_collection(self.collection_name, using=self.alias):
-            self.col = Collection(
-                self.collection_name,
-                using=self.alias,
-            )
+        if self.client.has_collection(self.collection_name):
+            self.col = True
             if self.collection_properties is not None:
-                self.col.set_properties(self.collection_properties)
+                self.client.alter_collection_properties(self.collection_name, self.collection_properties)
         # If need to drop old, drop it
-        if drop_old and isinstance(self.col, Collection):
-            self.col.drop()
-            self.col = None
+        if drop_old and self.col:
+            self.client.drop_collection(self.collection_name)
+            self.col = False
 
         # Initialize the vector store
-        self._init(
-            partition_names=partition_names,
-            replica_number=replica_number,
-            timeout=timeout,
-        )
+        self._init(timeout=timeout)
         self._dummy_value = 999.0
 
     def _check_function(self):
@@ -256,12 +244,13 @@ class MilvusDocumentStore:
 
         :return: The number of documents in the document store.
         """
-        if self.col is None:
+        if not self.col:
             logger.debug("No existing collection to count.")
             return 0
         count_expr = "count(*)"
-        res = self.col.query(
-            expr="",
+        res = self.client.query(
+            self.collection_name,
+            filter="",
             output_fields=[count_expr],
         )
         doc_num = res[0][count_expr]
@@ -333,7 +322,7 @@ class MilvusDocumentStore:
         :param filters: The filters to apply to the document list.
         :return: A list of Documents that match the given filters.
         """
-        if self.col is None:
+        if not self.col:
             logger.debug("No existing collection to filter.")
             return []
         output_fields = self._get_output_fields()
@@ -346,8 +335,9 @@ class MilvusDocumentStore:
 
         # Perform the Query.
         try:
-            res = self.col.query(
-                expr=expr,
+            res = self.client.query(
+                self.collection_name,
+                filter=expr,
                 output_fields=output_fields,
                 limit=MAX_LIMIT_SIZE,
             )
@@ -433,7 +423,7 @@ class MilvusDocumentStore:
 
         # If the collection hasn't been initialized yet, perform all steps to do so
         kwargs: Dict[str, Any] = {}
-        if not isinstance(self.col, Collection):
+        if not self.col:
             kwargs = {"embeddings": embeddings, "metas": metas}
             if self.partition_names:
                 kwargs["partition_names"] = self.partition_names
@@ -468,7 +458,7 @@ class MilvusDocumentStore:
         total_count = len(insert_list)
         batch_size = 1000
         wrote_ids = []
-        if not isinstance(self.col, Collection):
+        if not self.col:
             raise MilvusException(message="Collection is not initialized")
         for i in range(0, total_count, batch_size):
             # Grab end index
@@ -476,9 +466,8 @@ class MilvusDocumentStore:
             batch_insert_list = insert_list[i:end]
             # Insert into the collection.
             try:
-                # res: Collection
-                res = self.col.insert(batch_insert_list, timeout=None, **kwargs)
-                wrote_ids.extend(res.primary_keys)
+                res = self.client.insert(self.collection_name, batch_insert_list, timeout=None)
+                wrote_ids.extend(res["ids"])
             except MilvusException as err:
                 logger.error("Failed to insert batch starting at entity: %s/%s", i, total_count)
                 raise err
@@ -490,12 +479,12 @@ class MilvusDocumentStore:
 
         :param document_ids: The object_ids to delete
         """
-        if self.col is None:
+        if not self.col:
             logger.debug("No existing collection to delete.")
             return None
         expr = "id in ['" + "','".join(document_ids) + "']"
         logger.info(expr)
-        self.col.delete(expr)
+        self.client.delete(self.collection_name, filter=expr)
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -567,20 +556,15 @@ class MilvusDocumentStore:
         self,
         embeddings: Optional[List] = None,
         metas: Optional[List[Dict]] = None,
-        partition_names: Optional[List] = None,
-        replica_number: int = 1,
         timeout: Optional[float] = None,
+        **_kwargs: Any,
     ) -> None:
         if embeddings is not None:
             self._create_collection(embeddings, metas)
         self._extract_fields()
         self._create_index()
         self._create_search_params()
-        self._load(
-            partition_names=partition_names,
-            replica_number=replica_number,
-            timeout=timeout,
-        )
+        self._load(timeout=timeout)
 
     def _create_collection(self, embeddings: list, metas: Optional[List[Dict]] = None) -> None:
         # Determine embedding dim
@@ -625,29 +609,29 @@ class MilvusDocumentStore:
 
         # Create the collection
         try:
-            self.col = Collection(
-                name=self.collection_name,
+            self.client.create_collection(
+                collection_name=self.collection_name,
                 schema=schema,
                 consistency_level=self.consistency_level,
-                using=self.alias,
             )
+            self.col = True
             # Set the collection properties if they exist
             if self.collection_properties is not None:
-                self.col.set_properties(self.collection_properties)
+                self.client.alter_collection_properties(self.collection_name, self.collection_properties)
         except MilvusException as err:
             logger.error("Failed to create collection: %s error: %s", self.collection_name, err)
             raise err
 
     def _extract_fields(self) -> None:
         """Grab the existing fields from the Collection"""
-        if isinstance(self.col, Collection):
-            schema = self.col.schema
-            for x in schema.fields:
-                self.fields.append(x.name)
+        if self.col:
+            schema_info = self.client.describe_collection(self.collection_name)
+            for x in schema_info["fields"]:
+                self.fields.append(x["name"])
 
     def _create_index(self) -> None:
         """Create an index on the collection"""
-        if isinstance(self.col, Collection) and self._get_index() is None:
+        if self.col and self._get_index() is None:
             try:
                 # If no index params, use a default AUTOINDEX based one
                 if self.index_params is None:
@@ -658,11 +642,9 @@ class MilvusDocumentStore:
                     }
 
                 try:
-                    self.col.create_index(
-                        self._vector_field,
-                        index_params=self.index_params,
-                        using=self.alias,
-                    )
+                    index_params = self.client.prepare_index_params()
+                    index_params.add_index(field_name=self._vector_field, **self.index_params)
+                    self.client.create_index(self.collection_name, index_params)
 
                 # If default did not work, most likely on Zilliz Cloud
                 except MilvusException:
@@ -672,11 +654,10 @@ class MilvusDocumentStore:
                         "index_type": "AUTOINDEX",
                         "params": {},
                     }
-                    self.col.create_index(
-                        self._vector_field,
-                        index_params=self.index_params,
-                        using=self.alias,
-                    )
+                    index_params = self.client.prepare_index_params()
+                    index_params.add_index(field_name=self._vector_field, **self.index_params)
+                    self.client.create_index(self.collection_name, index_params)
+
                 if self._sparse_vector_field:
                     if self.sparse_index_params is None:
                         if self._sparse_mode == EmbeddingMode.EMBEDDING_MODEL:
@@ -690,11 +671,9 @@ class MilvusDocumentStore:
                                 "metric_type": "BM25",
                                 "params": {},
                             }
-                    self.col.create_index(
-                        self._sparse_vector_field,
-                        index_params=self.sparse_index_params,
-                        using=self.alias,
-                    )
+                    sparse_index_params = self.client.prepare_index_params()
+                    sparse_index_params.add_index(field_name=self._sparse_vector_field, **self.sparse_index_params)
+                    self.client.create_index(self.collection_name, sparse_index_params)
 
                 logger.debug(
                     "Successfully created an index on collection: %s",
@@ -707,39 +686,28 @@ class MilvusDocumentStore:
 
     def _create_search_params(self) -> None:
         """Generate search params based on the current index type"""
-        if isinstance(self.col, Collection) and self.search_params is None:
+        if self.col and self.search_params is None:
             index = self._get_index()
             if index is not None:
-                index_type: str = index["index_param"]["index_type"]
-                metric_type: str = index["index_param"]["metric_type"]
+                index_type: str = index["index_type"]
+                metric_type: str = index["metric_type"]
                 self.search_params = self.default_search_params[index_type]  # {"metric_type": "L2", "params": {}}
                 self.search_params["metric_type"] = metric_type
 
     def _get_index(self) -> Optional[Dict[str, Any]]:
         """Return the vector index information if it exists"""
-        if isinstance(self.col, Collection):
-            for x in self.col.indexes:
-                if x.field_name == self._vector_field:
-                    return x.to_dict()
+        if self.col:
+            return self.client.describe_index(self.collection_name, self._vector_field)
         return None
 
-    def _load(
-        self,
-        partition_names: Optional[list] = None,
-        replica_number: int = 1,
-        timeout: Optional[float] = None,
-    ) -> None:
+    def _load(self, timeout: Optional[float] = None) -> None:
         """Load the collection if available."""
         if (
-            isinstance(self.col, Collection)
+            self.col
             and self._get_index() is not None
-            and utility.load_state(self.collection_name, using=self.alias) == LoadState.NotLoad
+            and self.client.get_load_state(self.collection_name)["state"] == LoadState.NotLoad
         ):
-            self.col.load(
-                partition_names=partition_names,
-                replica_number=replica_number,
-                timeout=timeout,
-            )
+            self.client.load_collection(self.collection_name, timeout=timeout)
 
     def _resolve_value(self, secret: Union[str, Secret]):
         if isinstance(secret, Secret):
@@ -762,7 +730,7 @@ class MilvusDocumentStore:
         query_text: Optional[str] = None,
     ) -> List[Document]:
         """Dense embedding retrieval"""
-        if self.col is None:
+        if not self.col:
             logger.debug("No existing collection to search.")
             return []
 
@@ -770,7 +738,7 @@ class MilvusDocumentStore:
 
         # Build expr.
         if not filters:
-            expr = None
+            expr = ""
         else:
             expr = parse_filters(filters)
 
@@ -778,12 +746,13 @@ class MilvusDocumentStore:
         search_data = self._prepare_search_data(
             query_text=query_text, query_embedding=query_embedding, field=self._vector_field
         )
-        res = self.col.search(
+        res = self.client.search(
+            self.collection_name,
             data=[search_data],
             anns_field=self._vector_field,
-            param=self.search_params,
+            search_params=self.search_params,
             limit=top_k,
-            expr=expr,
+            filter=expr,
             output_fields=output_fields,
             timeout=None,
         )
@@ -799,7 +768,7 @@ class MilvusDocumentStore:
         query_text: Optional[str] = None,
     ) -> List[Document]:
         """Sparse embedding retrieval"""
-        if self.col is None:
+        if not self.col:
             logger.debug("No existing collection to search.")
             return []
         if self._sparse_vector_field is None:
@@ -820,7 +789,7 @@ class MilvusDocumentStore:
 
         # Build expr.
         if not filters:
-            expr = None
+            expr = ""
         else:
             expr = parse_filters(filters)
 
@@ -829,12 +798,13 @@ class MilvusDocumentStore:
             query_text=query_text, query_embedding=query_sparse_embedding, field=self._sparse_vector_field
         )
 
-        res = self.col.search(
+        res = self.client.search(
+            self.collection_name,
             data=[search_data],
             anns_field=self._sparse_vector_field,
-            param=self.sparse_search_params,
+            search_params=self.sparse_search_params,
             limit=top_k,
-            expr=expr,
+            filter=expr,
             output_fields=output_fields,
             timeout=None,
         )
@@ -851,7 +821,7 @@ class MilvusDocumentStore:
         query_text: Optional[str] = None,
     ) -> List[Document]:
         """Hybrid retrieval using both dense and sparse embeddings"""
-        if self.col is None:
+        if not self.col:
             logger.debug("No existing collection to search.")
             return []
         if self._sparse_vector_field is None:
@@ -875,7 +845,7 @@ class MilvusDocumentStore:
 
         # Build expr.
         if not filters:
-            expr = None
+            expr = ""
         else:
             expr = parse_filters(filters)
 
@@ -897,14 +867,16 @@ class MilvusDocumentStore:
         )
 
         # Search topK docs based on dense and sparse vectors and rerank.
-        res = self.col.hybrid_search([dense_req, sparse_req], rerank=reranker, limit=top_k, output_fields=output_fields)
+        res = self.client.hybrid_search(
+            self.collection_name, [dense_req, sparse_req], ranker=reranker, limit=top_k, output_fields=output_fields
+        )
         docs = self._parse_search_result(res)
         return docs
 
     def _parse_search_result(self, result, distance_to_score_fn=lambda x: x) -> List[Document]:
         docs = []
         for res in result[0]:
-            data = {x: res.entity.get(x) for x in res.entity.fields}
+            data = dict(res.fields)
             doc = self._parse_document(data)
             doc.score = distance_to_score_fn(res.distance)
             docs.append(doc)

--- a/src/milvus_haystack/document_store.py
+++ b/src/milvus_haystack/document_store.py
@@ -252,6 +252,7 @@ class MilvusDocumentStore:
             self.collection_name,
             filter="",
             output_fields=[count_expr],
+            partition_names=self.partition_names,
         )
         doc_num = res[0][count_expr]
         return doc_num
@@ -340,6 +341,7 @@ class MilvusDocumentStore:
                 filter=expr,
                 output_fields=output_fields,
                 limit=MAX_LIMIT_SIZE,
+                partition_names=self.partition_names,
             )
         except MilvusException as err:
             logger.error("Failed to query documents with filters expr: %s", expr)
@@ -422,16 +424,8 @@ class MilvusDocumentStore:
             return 0
 
         # If the collection hasn't been initialized yet, perform all steps to do so
-        kwargs: Dict[str, Any] = {}
         if not self.col:
-            kwargs = {"embeddings": embeddings, "metas": metas}
-            if self.partition_names:
-                kwargs["partition_names"] = self.partition_names
-            if self.replica_number:
-                kwargs["replica_number"] = self.replica_number
-            if self.timeout:
-                kwargs["timeout"] = self.timeout
-            self._init(**kwargs)
+            self._init(embeddings=embeddings, metas=metas, timeout=self.timeout)
 
         insert_list: list[dict] = []
         for i in range(len(ids)):
@@ -557,7 +551,6 @@ class MilvusDocumentStore:
         embeddings: Optional[List] = None,
         metas: Optional[List[Dict]] = None,
         timeout: Optional[float] = None,
-        **_kwargs: Any,
     ) -> None:
         if embeddings is not None:
             self._create_collection(embeddings, metas)
@@ -754,6 +747,7 @@ class MilvusDocumentStore:
             limit=top_k,
             filter=expr,
             output_fields=output_fields,
+            partition_names=self.partition_names,
             timeout=None,
         )
         distance_to_score_fn = self._select_score_fn()
@@ -806,6 +800,7 @@ class MilvusDocumentStore:
             limit=top_k,
             filter=expr,
             output_fields=output_fields,
+            partition_names=self.partition_names,
             timeout=None,
         )
         docs = self._parse_search_result(res)
@@ -868,7 +863,12 @@ class MilvusDocumentStore:
 
         # Search topK docs based on dense and sparse vectors and rerank.
         res = self.client.hybrid_search(
-            self.collection_name, [dense_req, sparse_req], ranker=reranker, limit=top_k, output_fields=output_fields
+            self.collection_name,
+            [dense_req, sparse_req],
+            ranker=reranker,
+            limit=top_k,
+            output_fields=output_fields,
+            partition_names=self.partition_names,
         )
         docs = self._parse_search_result(res)
         return docs

--- a/src/milvus_haystack/document_store.py
+++ b/src/milvus_haystack/document_store.py
@@ -11,12 +11,14 @@ from haystack.errors import FilterError
 from haystack.utils import Secret, deserialize_secrets_inplace
 from pymilvus import (
     AnnSearchRequest,
+    Collection,
     CollectionSchema,
     DataType,
     FieldSchema,
     MilvusClient,
     MilvusException,
     RRFRanker,
+    connections,
 )
 from pymilvus.client.abstract import BaseRanker
 from pymilvus.client.types import LoadState
@@ -195,17 +197,22 @@ class MilvusDocumentStore:
         resolved_args = connection_args if connection_args is not None else DEFAULT_MILVUS_CONNECTION
         self.connection_args = resolved_args
         self._milvus_client = MilvusClient(**resolved_args)
-        self.col: bool = False  # True when the collection is ready to use
+        self.alias = self.client._using
+        # Since pymilvus 2.6.x, MilvusClient no longer registers its connection
+        # with the ORM `connections` registry; register its handler so the ORM
+        # `Collection` exposed by `self.col` can find the connection.
+        if hasattr(connections, "_alias_handlers"):
+            connections._alias_handlers.setdefault(self.alias, self.client._get_connection())
+        self._col_cache: Optional[Collection] = None
+        self._cache_key: Optional[str] = None
 
-        # Grab the existing collection if it exists
+        # Apply properties to the existing collection if it exists
         if self.client.has_collection(self.collection_name):
-            self.col = True
             if self.collection_properties is not None:
                 self.client.alter_collection_properties(self.collection_name, self.collection_properties)
-        # If need to drop old, drop it
-        if drop_old and self.col:
-            self.client.drop_collection(self.collection_name)
-            self.col = False
+            # If need to drop old, drop it
+            if drop_old:
+                self._drop_collection()
 
         # Initialize the vector store
         self._init(timeout=timeout)
@@ -238,13 +245,40 @@ class MilvusDocumentStore:
         """Get client."""
         return self._milvus_client
 
+    @property
+    def col(self) -> Optional[Collection]:
+        """The ORM Collection object, or None if the collection does not exist.
+
+        Kept for backward compatibility with code that accesses `store.col`;
+        internal operations use the `MilvusClient` API via `self.client`.
+        """
+        current_key = f"{self.collection_name}:{self.alias}"
+        if self._cache_key == current_key and self._col_cache is not None:
+            return self._col_cache
+        if self.client.has_collection(self.collection_name):
+            self._col_cache = Collection(self.collection_name, using=self.alias)
+            self._cache_key = current_key
+            return self._col_cache
+        return None
+
+    def _drop_collection(self) -> None:
+        self.client.drop_collection(self.collection_name)
+        # pymilvus keeps the dropped collection's schema in a connection-level
+        # cache, so recreating a collection with the same name can read back
+        # stale schema. See https://github.com/milvus-io/pymilvus/issues/3058
+        conn = self.client._get_connection()
+        if hasattr(conn, "schema_cache"):
+            conn.schema_cache.pop(self.collection_name, None)
+        self._col_cache = None
+        self._cache_key = None
+
     def count_documents(self) -> int:
         """
         Returns how many documents are present in the document store.
 
         :return: The number of documents in the document store.
         """
-        if not self.col:
+        if self.col is None:
             logger.debug("No existing collection to count.")
             return 0
         count_expr = "count(*)"
@@ -323,7 +357,7 @@ class MilvusDocumentStore:
         :param filters: The filters to apply to the document list.
         :return: A list of Documents that match the given filters.
         """
-        if not self.col:
+        if self.col is None:
             logger.debug("No existing collection to filter.")
             return []
         output_fields = self._get_output_fields()
@@ -424,7 +458,7 @@ class MilvusDocumentStore:
             return 0
 
         # If the collection hasn't been initialized yet, perform all steps to do so
-        if not self.col:
+        if self.col is None:
             self._init(embeddings=embeddings, metas=metas, timeout=self.timeout)
 
         insert_list: list[dict] = []
@@ -452,7 +486,7 @@ class MilvusDocumentStore:
         total_count = len(insert_list)
         batch_size = 1000
         wrote_ids = []
-        if not self.col:
+        if self.col is None:
             raise MilvusException(message="Collection is not initialized")
         for i in range(0, total_count, batch_size):
             # Grab end index
@@ -473,7 +507,7 @@ class MilvusDocumentStore:
 
         :param document_ids: The object_ids to delete
         """
-        if not self.col:
+        if self.col is None:
             logger.debug("No existing collection to delete.")
             return None
         expr = "id in ['" + "','".join(document_ids) + "']"
@@ -607,7 +641,6 @@ class MilvusDocumentStore:
                 schema=schema,
                 consistency_level=self.consistency_level,
             )
-            self.col = True
             # Set the collection properties if they exist
             if self.collection_properties is not None:
                 self.client.alter_collection_properties(self.collection_name, self.collection_properties)
@@ -617,14 +650,14 @@ class MilvusDocumentStore:
 
     def _extract_fields(self) -> None:
         """Grab the existing fields from the Collection"""
-        if self.col:
+        if self.col is not None:
             schema_info = self.client.describe_collection(self.collection_name)
             for x in schema_info["fields"]:
                 self.fields.append(x["name"])
 
     def _create_index(self) -> None:
         """Create an index on the collection"""
-        if self.col and self._get_index() is None:
+        if self.col is not None and self._get_index() is None:
             try:
                 # If no index params, use a default AUTOINDEX based one
                 if self.index_params is None:
@@ -679,28 +712,46 @@ class MilvusDocumentStore:
 
     def _create_search_params(self) -> None:
         """Generate search params based on the current index type"""
-        if self.col and self.search_params is None:
+        if self.col is not None and self.search_params is None:
             index = self._get_index()
             if index is not None:
-                index_type: str = index["index_type"]
-                metric_type: str = index["metric_type"]
+                index_type: str = index["index_param"]["index_type"]
+                metric_type: str = index["index_param"]["metric_type"]
                 self.search_params = self.default_search_params[index_type]  # {"metric_type": "L2", "params": {}}
                 self.search_params["metric_type"] = metric_type
 
     def _get_index(self) -> Optional[Dict[str, Any]]:
         """Return the vector index information if it exists"""
-        if self.col:
-            return self.client.describe_index(self.collection_name, self._vector_field)
+        # `MilvusClient.describe_index` raises when the field has no index yet,
+        # so keep the ORM index iteration here: it simply yields nothing on the
+        # first-time index creation path.
+        col = self.col
+        if col is not None:
+            for x in col.indexes:
+                if x.field_name == self._vector_field:
+                    return x.to_dict()
         return None
 
     def _load(self, timeout: Optional[float] = None) -> None:
         """Load the collection if available."""
         if (
-            self.col
+            self.col is not None
             and self._get_index() is not None
             and self.client.get_load_state(self.collection_name)["state"] == LoadState.NotLoad
         ):
-            self.client.load_collection(self.collection_name, timeout=timeout)
+            if self.partition_names:
+                self.client.load_partitions(
+                    self.collection_name,
+                    partition_names=self.partition_names,
+                    replica_number=self.replica_number,
+                    timeout=timeout,
+                )
+            else:
+                self.client.load_collection(
+                    self.collection_name,
+                    replica_number=self.replica_number,
+                    timeout=timeout,
+                )
 
     def _resolve_value(self, secret: Union[str, Secret]):
         if isinstance(secret, Secret):
@@ -723,7 +774,7 @@ class MilvusDocumentStore:
         query_text: Optional[str] = None,
     ) -> List[Document]:
         """Dense embedding retrieval"""
-        if not self.col:
+        if self.col is None:
             logger.debug("No existing collection to search.")
             return []
 
@@ -762,7 +813,7 @@ class MilvusDocumentStore:
         query_text: Optional[str] = None,
     ) -> List[Document]:
         """Sparse embedding retrieval"""
-        if not self.col:
+        if self.col is None:
             logger.debug("No existing collection to search.")
             return []
         if self._sparse_vector_field is None:
@@ -816,7 +867,7 @@ class MilvusDocumentStore:
         query_text: Optional[str] = None,
     ) -> List[Document]:
         """Hybrid retrieval using both dense and sparse embeddings"""
-        if not self.col:
+        if self.col is None:
             logger.debug("No existing collection to search.")
             return []
         if self._sparse_vector_field is None:


### PR DESCRIPTION
## Summary

- Replaces all legacy ORM-based operations (`Collection`, `utility.*`) with the modern `MilvusClient` API, compatible with both pymilvus 2.5.x and 2.6.x
- Migrates `create_collection`, `drop_collection`, `has_collection`, `insert`, `delete`, `search`, `query`, `hybrid_search`, `describe_collection`, `create_index`, `load_collection`, and `get_load_state` to `MilvusClient` equivalents
- Fixes `partition_names` not being forwarded to `search`, `query`, `hybrid_search`, and `count_documents` operations

## Key changes

- `self.col` remains `Optional[Collection]` for backward compatibility, now implemented as a cached `@property` (same approach as langchain-milvus); all internal operations use `MilvusClient`. Since pymilvus 2.6.x no longer registers the client connection with the ORM `connections` registry, the store registers the client's gRPC handler itself so the ORM `Collection` can resolve the alias — this works on both 2.5.x and 2.6.x
- `self.alias` is kept as a public attribute
- Index creation uses `prepare_index_params()` / `add_index()` / `create_index()`
- `_get_index` keeps the ORM `col.indexes` iteration: `MilvusClient.describe_index` raises when the field has no index yet, which would break the first-time index creation path
- `replica_number` is forwarded to `load_collection` / `load_partitions` (no longer a silent no-op)
- Dropping a collection also clears pymilvus's connection-level schema cache (see milvus-io/pymilvus#3058), so `drop_old=True` cannot read back stale schema
- Search parameter key renamed from `param=` (ORM) to `search_params=` (MilvusClient); filter parameter renamed from `expr=` to `filter=` for search/query (`AnnSearchRequest` still uses `expr=`, correct per its API); `hybrid_search` ranker kwarg renamed from `rerank=` to `ranker=`
- `_parse_search_result` updated: `dict(res.fields)` replaces the ORM entity field iteration
- CI now runs the test suite against both pymilvus 2.5.x and 2.6.x

## Notes

- `from pymilvus.orm.types import infer_dtype_bydata` remains as an ORM-module import; this function is a pure utility (no ORM state) that is not exported from the top-level `pymilvus` namespace and cannot be eliminated without duplicating its logic
- Full test suite passes locally against Milvus 2.6.14 with both pymilvus 2.5.18 and 2.6.11
